### PR TITLE
Optimize aws resource calls

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -2,6 +2,9 @@
 package util
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/google/uuid"
 )
 
@@ -9,4 +12,27 @@ import (
 func GenerateUUID() string {
 	u := uuid.New()
 	return u.String()
+}
+
+// RetryWithExponentialBackoff retries a function with exponential backoff in case of errors
+func RetryWithExponentialBackoff(fn func() error, maxRetries int, initialBackoffSeconds int) error {
+	backoff := time.Duration(initialBackoffSeconds) * time.Second
+	subsequentBackoff := 2
+
+	for i := 0; ; i++ {
+		fmt.Println("Retrying....")
+		err := fn()
+		if err == nil {
+			return nil
+		}
+
+		if i == maxRetries {
+			return fmt.Errorf("maximum number of retries exceeded: %w", err)
+		}
+
+		//log.Printf("Error occurred: %v. Retrying in %v", err, backoff)
+		time.Sleep(backoff)
+
+		backoff *= time.Duration(subsequentBackoff)
+	}
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"errors"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -11,5 +13,26 @@ func TestGenerateUUID(t *testing.T) {
 	// Verify that the UUID is in the correct format
 	if len(uuid) != 36 {
 		t.Errorf("UUID is not in the correct format: %s", uuid)
+	}
+}
+
+func TestRetryWithExponentialBackoff(t *testing.T) {
+	// Define the function to retry
+	fn := func() error {
+		return errors.New("error")
+	}
+
+	// Define the maximum number of retries and the backoff intervals
+	maxRetries := 1
+	initialBackoff := 1
+
+	// Call the function with retry and check the result
+	err := RetryWithExponentialBackoff(fn, maxRetries, initialBackoff)
+	assert.Error(t, err)
+
+	// Check the error message
+	expectedErrorMessage := "maximum number of retries exceeded: error"
+	if err.Error() != expectedErrorMessage {
+		t.Errorf("unexpected error message: got %v, want %v", err.Error(), expectedErrorMessage)
 	}
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -2,8 +2,10 @@ package util
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
+
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateUUID(t *testing.T) {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -3,9 +3,9 @@ package util
 import (
 	"errors"
 
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+
+	"testing"
 )
 
 func TestGenerateUUID(t *testing.T) {
@@ -19,22 +19,46 @@ func TestGenerateUUID(t *testing.T) {
 }
 
 func TestRetryWithExponentialBackoff(t *testing.T) {
-	// Define the function to retry
-	fn := func() error {
-		return errors.New("error")
+	testCases := []struct {
+		name        string
+		callback    func() error
+		expectError bool
+	}{
+		{
+			name: "function returns error",
+			callback: func() error {
+				return errors.New("error")
+			},
+			expectError: true,
+		},
+		{
+			name: "function returns no error",
+			callback: func() error {
+				return nil
+			},
+			expectError: false,
+		},
 	}
 
-	// Define the maximum number of retries and the backoff intervals
-	maxRetries := 1
-	initialBackoff := 1
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Define the maximum number of retries and the backoff intervals
+			maxRetries := 1
+			initialBackoff := 1
 
-	// Call the function with retry and check the result
-	err := RetryWithExponentialBackoff(fn, maxRetries, initialBackoff)
-	assert.Error(t, err)
+			// Call the function with retry and check the result
+			err := RetryWithExponentialBackoff(tc.callback, maxRetries, initialBackoff)
 
-	// Check the error message
-	expectedErrorMessage := "maximum number of retries exceeded: error"
-	if err.Error() != expectedErrorMessage {
-		t.Errorf("unexpected error message: got %v, want %v", err.Error(), expectedErrorMessage)
+			if tc.expectError {
+				assert.Error(t, err)
+				// Check the error message
+				expectedErrorMessage := "maximum number of retries exceeded: error"
+				if err.Error() != expectedErrorMessage {
+					t.Errorf("unexpected error message: got %v, want %v", err.Error(), expectedErrorMessage)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
For AWS RDS, AWS is throwing `API rate limit exceeded` error specially during getting the tags for each RDS instance. To avoid this, implemented exponential back-off strategy during fetching AWS RDS tag lists that can reduce pressure on API call.