### PR TITLE
Copy configuration from different sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /build/*
-!/build/.gitkeep
 
 /.idea
 

--- a/README.md
+++ b/README.md
@@ -189,14 +189,10 @@ source:
       secret_key: "xxxx"
       session_token: "xxxx"
       region: "x"
+      account_id: "xxx
   aws_rds_one:
     type: aws_rds
-    configuration:
-      access_key: "xxxx"
-      secret_key: "xxxx"
-      session_token: "xxxx"
-      region: "x"
-      account_id: "xxx
+    config_from: aws_s3_one
 relations:
   criteria:
     - name: "file-system-rule1"
@@ -287,6 +283,7 @@ source:
       secret_key: "xxxx"
       session_token: "xxxx"
       region: "x"
+      account_id: "xxx"
 ```
 
 #### Available metadata for AWS S3 Source

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,7 +37,6 @@ type SourceConfiguration struct {
 type Source struct {
 	Type          string            `yaml:"type"`
 	Configuration map[string]string `yaml:"configuration"`
-	ResourceTypes []string          `yaml:"resource_types,omitempty"`
 	DependsOn     []string          `yaml:"depends_on,omitempty"`
 }
 
@@ -241,10 +240,6 @@ func (c *AppConfig) validateSourceConfiguration(name string, source Source) erro
 		if err := c.validateConfigurationKeys(name, source, "access_key", "secret_key", "session_token", "region", "account_id"); err != nil {
 			return err
 		}
-
-		if err := c.validateAWSResourceTypes(name, source); err != nil {
-			return err
-		}
 	default:
 		return fmt.Errorf("unknown source type: '%s'", source.Type)
 	}
@@ -256,25 +251,6 @@ func (c *AppConfig) validateConfigurationKeys(sourceName string, source Source, 
 		keyNotEmpty, ok := source.Configuration[k]
 		if !ok || keyNotEmpty == "" {
 			return fmt.Errorf("source '%s' requires 'configuration.%s'", k, sourceName)
-		}
-	}
-
-	return nil
-}
-
-func (c *AppConfig) validateAWSResourceTypes(sourceName string, source Source) error {
-	if source.ResourceTypes == nil || len(source.ResourceTypes) == 0 {
-		return nil
-	}
-
-	validResourceTypes := map[string]bool{
-		"s3":  true,
-		"rds": true,
-	}
-
-	for _, resourceType := range source.ResourceTypes {
-		if _, ok := validResourceTypes[resourceType]; !ok {
-			return fmt.Errorf("resource type: %s is not valid for source: %s", resourceType, sourceName)
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,6 +36,7 @@ type SourceConfiguration struct {
 // Source holds source configuration
 type Source struct {
 	Type          string            `yaml:"type"`
+	ConfigFrom    string            `yaml:"config_from,omitempty"`
 	Configuration map[string]string `yaml:"configuration"`
 	DependsOn     []string          `yaml:"depends_on,omitempty"`
 }
@@ -86,6 +87,19 @@ func Load(path string) (*AppConfig, error) {
 	err = yaml.Unmarshal(yamlFile, &appConfig)
 	if err != nil {
 		return &appConfig, fmt.Errorf("failed to unmarshal YAML data: %w", err)
+	}
+
+	sourceConfigs := map[string]map[string]string{}
+	for sourceName, s := range appConfig.Sources {
+		sourceConfigs[sourceName] = s.Configuration
+	}
+
+	for name, source := range appConfig.Sources {
+		if source.ConfigFrom != "" && sourceConfigs[source.ConfigFrom] != nil {
+			sourceConfiguration := sourceConfigs[source.ConfigFrom]
+			source.Configuration = sourceConfiguration
+			appConfig.Sources[name] = source
+		}
 	}
 
 	return &appConfig, nil
@@ -233,7 +247,7 @@ func (c *AppConfig) validateSourceConfiguration(name string, source Source) erro
 			return err
 		}
 	case pkg.SourceTypeAWSS3:
-		if err := c.validateConfigurationKeys(name, source, "access_key", "secret_key", "session_token", "region"); err != nil {
+		if err := c.validateConfigurationKeys(name, source, "access_key", "secret_key", "session_token", "region", "account_id"); err != nil {
 			return err
 		}
 	case pkg.SourceTypeAWSRDS:

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -24,6 +24,16 @@ func TestLoad(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestLoadAndValidateConfigYaml(t *testing.T) {
+	// Test with valid config file
+	path := "testdata/valid_config.yaml"
+	appConfig, loadError := Load(path)
+	assert.NoError(t, loadError)
+
+	validationError := Validate(appConfig)
+	assert.NoError(t, validationError)
+}
+
 func TestValidate(t *testing.T) {
 	testCases := []struct {
 		name    string
@@ -64,6 +74,16 @@ func TestValidate(t *testing.T) {
 							"branch":        "mybranch",
 							"path":          "mypath",
 							"file_patterns": "*.yaml",
+						},
+					},
+					"source3": {
+						Type: pkg.SourceTypeAWSS3,
+						Configuration: map[string]string{
+							"access_key":    "access_key",
+							"secret_key":    "secret_key",
+							"session_token": "session_token",
+							"region":        "x",
+							"account_id":    "account_id",
 						},
 					},
 				},
@@ -1623,6 +1643,53 @@ func TestValidate(t *testing.T) {
 							"account_id":    "xxx",
 							"region":        "xxxx",
 							"secret_key":    "xxxx",
+						},
+					},
+				},
+				Relation: Relation{RelationCriteria: []RelationCriteria{
+					{
+						Name: "name",
+						Source: RelationCriteriaNode{
+							Kind:      "kind",
+							MetaKey:   "source_kind-key1",
+							MetaValue: "source-kind-value1",
+						},
+						Target: RelationCriteriaNode{
+							Kind:      "related-kind",
+							MetaKey:   "related-metadata-key",
+							MetaValue: "related-metadata-value",
+						},
+					}},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing account_id for AWS S3 source",
+			config: AppConfig{
+				Organization: Organization{Name: "My Org", Logo: "http://example.com"},
+				Discovery:    Discovery{Name: "My Discovery", Description: "Discovery description"},
+				Storage: Storage{
+					BatchSize:     2,
+					DefaultEngine: "postgresql",
+					Engines: map[string]interface{}{
+						"postgresql": map[string]interface{}{
+							"host":     "localhost",
+							"port":     5432,
+							"user":     "myuser",
+							"password": "mypassword",
+							"db":       "mydb",
+						},
+					},
+				},
+				Sources: map[string]Source{
+					"source1": {
+						Type: pkg.SourceTypeAWSRDS,
+						Configuration: map[string]string{
+							"session_token": "session",
+							"region":        "xxxx",
+							"secret_key":    "xxxx",
+							"access_key":    "xxxx",
 						},
 					},
 				},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -66,6 +66,17 @@ func TestValidate(t *testing.T) {
 							"file_patterns": "*.yaml",
 						},
 					},
+					"aws": {
+						Type: pkg.SourceTypeAWSRDS,
+						Configuration: map[string]string{
+							"access_key":    "access",
+							"secret_key":    "secret",
+							"account_id":    "xxx",
+							"region":        "eu-west",
+							"session_token": "xxxx",
+						},
+						ResourceTypes: []string{"rds", "s3"},
+					},
 				},
 				Relation: Relation{RelationCriteria: []RelationCriteria{
 					{
@@ -1736,6 +1747,104 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			wantErr: true,
+		},
+		{
+			name: "invalid AWS resource types",
+			config: AppConfig{
+				Organization: Organization{Name: "My Org", Logo: "http://example.com"},
+				Discovery:    Discovery{Name: "My Discovery", Description: "Discovery description"},
+				Storage: Storage{
+					BatchSize:     2,
+					DefaultEngine: "postgresql",
+					Engines: map[string]interface{}{
+						"postgresql": map[string]interface{}{
+							"host":     "localhost",
+							"port":     5432,
+							"user":     "myuser",
+							"password": "mypassword",
+							"db":       "mydb",
+						},
+					},
+				},
+				Sources: map[string]Source{
+					"source1": {
+						Type: pkg.SourceTypeAWSRDS,
+						Configuration: map[string]string{
+							"access_key":    "access",
+							"secret_key":    "secret",
+							"account_id":    "xxx",
+							"region":        "eu-west",
+							"session_token": "xxxx",
+						},
+						ResourceTypes: []string{"invlaid_source_type", "rds"},
+					},
+				},
+				Relation: Relation{RelationCriteria: []RelationCriteria{
+					{
+						Name: "name",
+						Source: RelationCriteriaNode{
+							Kind:      "kind",
+							MetaKey:   "source_kind-key1",
+							MetaValue: "source-kind-value1",
+						},
+						Target: RelationCriteriaNode{
+							Kind:      "related-kind",
+							MetaKey:   "related-metadata-key",
+							MetaValue: "related-metadata-value",
+						},
+					}},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "aws resource types are empty",
+			config: AppConfig{
+				Organization: Organization{Name: "My Org", Logo: "http://example.com"},
+				Discovery:    Discovery{Name: "My Discovery", Description: "Discovery description"},
+				Storage: Storage{
+					BatchSize:     2,
+					DefaultEngine: "postgresql",
+					Engines: map[string]interface{}{
+						"postgresql": map[string]interface{}{
+							"host":     "localhost",
+							"port":     5432,
+							"user":     "myuser",
+							"password": "mypassword",
+							"db":       "mydb",
+						},
+					},
+				},
+				Sources: map[string]Source{
+					"source1": {
+						Type: pkg.SourceTypeAWSRDS,
+						Configuration: map[string]string{
+							"access_key":    "access",
+							"secret_key":    "secret",
+							"account_id":    "xxx",
+							"region":        "eu-west",
+							"session_token": "xxxx",
+						},
+						ResourceTypes: []string{},
+					},
+				},
+				Relation: Relation{RelationCriteria: []RelationCriteria{
+					{
+						Name: "name",
+						Source: RelationCriteriaNode{
+							Kind:      "kind",
+							MetaKey:   "source_kind-key1",
+							MetaValue: "source-kind-value1",
+						},
+						Target: RelationCriteriaNode{
+							Kind:      "related-kind",
+							MetaKey:   "related-metadata-key",
+							MetaValue: "related-metadata-value",
+						},
+					}},
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name: "missing region for AWS RDS source",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -66,17 +66,6 @@ func TestValidate(t *testing.T) {
 							"file_patterns": "*.yaml",
 						},
 					},
-					"aws": {
-						Type: pkg.SourceTypeAWSRDS,
-						Configuration: map[string]string{
-							"access_key":    "access",
-							"secret_key":    "secret",
-							"account_id":    "xxx",
-							"region":        "eu-west",
-							"session_token": "xxxx",
-						},
-						ResourceTypes: []string{"rds", "s3"},
-					},
 				},
 				Relation: Relation{RelationCriteria: []RelationCriteria{
 					{
@@ -1747,104 +1736,6 @@ func TestValidate(t *testing.T) {
 				},
 			},
 			wantErr: true,
-		},
-		{
-			name: "invalid AWS resource types",
-			config: AppConfig{
-				Organization: Organization{Name: "My Org", Logo: "http://example.com"},
-				Discovery:    Discovery{Name: "My Discovery", Description: "Discovery description"},
-				Storage: Storage{
-					BatchSize:     2,
-					DefaultEngine: "postgresql",
-					Engines: map[string]interface{}{
-						"postgresql": map[string]interface{}{
-							"host":     "localhost",
-							"port":     5432,
-							"user":     "myuser",
-							"password": "mypassword",
-							"db":       "mydb",
-						},
-					},
-				},
-				Sources: map[string]Source{
-					"source1": {
-						Type: pkg.SourceTypeAWSRDS,
-						Configuration: map[string]string{
-							"access_key":    "access",
-							"secret_key":    "secret",
-							"account_id":    "xxx",
-							"region":        "eu-west",
-							"session_token": "xxxx",
-						},
-						ResourceTypes: []string{"invlaid_source_type", "rds"},
-					},
-				},
-				Relation: Relation{RelationCriteria: []RelationCriteria{
-					{
-						Name: "name",
-						Source: RelationCriteriaNode{
-							Kind:      "kind",
-							MetaKey:   "source_kind-key1",
-							MetaValue: "source-kind-value1",
-						},
-						Target: RelationCriteriaNode{
-							Kind:      "related-kind",
-							MetaKey:   "related-metadata-key",
-							MetaValue: "related-metadata-value",
-						},
-					}},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "aws resource types are empty",
-			config: AppConfig{
-				Organization: Organization{Name: "My Org", Logo: "http://example.com"},
-				Discovery:    Discovery{Name: "My Discovery", Description: "Discovery description"},
-				Storage: Storage{
-					BatchSize:     2,
-					DefaultEngine: "postgresql",
-					Engines: map[string]interface{}{
-						"postgresql": map[string]interface{}{
-							"host":     "localhost",
-							"port":     5432,
-							"user":     "myuser",
-							"password": "mypassword",
-							"db":       "mydb",
-						},
-					},
-				},
-				Sources: map[string]Source{
-					"source1": {
-						Type: pkg.SourceTypeAWSRDS,
-						Configuration: map[string]string{
-							"access_key":    "access",
-							"secret_key":    "secret",
-							"account_id":    "xxx",
-							"region":        "eu-west",
-							"session_token": "xxxx",
-						},
-						ResourceTypes: []string{},
-					},
-				},
-				Relation: Relation{RelationCriteria: []RelationCriteria{
-					{
-						Name: "name",
-						Source: RelationCriteriaNode{
-							Kind:      "kind",
-							MetaKey:   "source_kind-key1",
-							MetaValue: "source-kind-value1",
-						},
-						Target: RelationCriteriaNode{
-							Kind:      "related-kind",
-							MetaKey:   "related-metadata-key",
-							MetaValue: "related-metadata-value",
-						},
-					}},
-				},
-			},
-			wantErr: false,
 		},
 		{
 			name: "missing region for AWS RDS source",

--- a/pkg/config/testdata/valid_config.yaml
+++ b/pkg/config/testdata/valid_config.yaml
@@ -36,14 +36,10 @@ source:
       secret_key: "xxxx"
       session_token: "xxxx"
       region: "x"
+      account_id: "xxx"
   aws_rds_one:
     type: aws_rds
-    configuration:
-      access_key: "xxxx"
-      secret_key: "xxxx"
-      session_token: "xxxx"
-      region: "x"
-      account_id: "xxx"
+    config_from: aws_s3_one
 relations:
   criteria:
     - name: "file-system-rule1"

--- a/pkg/config/testdata/valid_config.yaml
+++ b/pkg/config/testdata/valid_config.yaml
@@ -44,9 +44,6 @@ source:
       session_token: "xxxx"
       region: "x"
       account_id: "xxx"
-    resource_types:
-      - rds
-      - s3
 relations:
   criteria:
     - name: "file-system-rule1"

--- a/pkg/config/testdata/valid_config.yaml
+++ b/pkg/config/testdata/valid_config.yaml
@@ -44,6 +44,9 @@ source:
       session_token: "xxxx"
       region: "x"
       account_id: "xxx"
+    resource_types:
+      - rds
+      - s3
 relations:
   criteria:
     - name: "file-system-rule1"

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -3,7 +3,6 @@ package source
 
 import (
 	"context"
-	"fmt"
 	"teredix/pkg"
 	"teredix/pkg/config"
 	"teredix/pkg/source/scanner"
@@ -71,12 +70,6 @@ func BuildSources(appConfig *config.AppConfig) []Source {
 			awsCnf := aws.NewConfig().WithRegion(s.Configuration["region"]).WithCredentials(credentials.NewStaticCredentials(s.Configuration["access_key"], s.Configuration["secret_key"], s.Configuration["session_token"]))
 			newSession, _ := session.NewSession(awsCnf)
 			rdsClient := rds.New(newSession)
-
-			for _, t := range s.ResourceTypes {
-				fmt.Println(t)
-			}
-
-			panic(1)
 
 			awsS3 := scanner.NewAWSRDS(sourceKey, s.Configuration["region"], s.Configuration["account_id"], rdsClient)
 			finalSources = append(finalSources, Source{

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -3,6 +3,7 @@ package source
 
 import (
 	"context"
+	"fmt"
 	"teredix/pkg"
 	"teredix/pkg/config"
 	"teredix/pkg/source/scanner"
@@ -70,6 +71,12 @@ func BuildSources(appConfig *config.AppConfig) []Source {
 			awsCnf := aws.NewConfig().WithRegion(s.Configuration["region"]).WithCredentials(credentials.NewStaticCredentials(s.Configuration["access_key"], s.Configuration["secret_key"], s.Configuration["session_token"]))
 			newSession, _ := session.NewSession(awsCnf)
 			rdsClient := rds.New(newSession)
+
+			for _, t := range s.ResourceTypes {
+				fmt.Println(t)
+			}
+
+			panic(1)
 
 			awsS3 := scanner.NewAWSRDS(sourceKey, s.Configuration["region"], s.Configuration["account_id"], rdsClient)
 			finalSources = append(finalSources, Source{


### PR DESCRIPTION
Added support to copy configuration from different sources.

- `config_from` configuration key added to copy configuration from other source in config yaml file

It will reduce complexity to maintain config.yaml file. For example, you can use same credentials to fetch AWS resources (rds, s3, etc..). Adding same credentials for different resource types should be avoided